### PR TITLE
Fix Issue-34. Accents are not marshalled correctly

### DIFF
--- a/src/osrm.net/EngineConfig.cpp
+++ b/src/osrm.net/EngineConfig.cpp
@@ -9,6 +9,8 @@ using namespace Osrmnet;
 
 EngineConfig::EngineConfig() : engineConfig(new osrm::engine::EngineConfig())
 {
+	// Default shared memory is off
+	this->UseSharedMemory = false;
 }
 
 EngineConfig::~EngineConfig()

--- a/src/osrm.net/Route/RouteItem.cpp
+++ b/src/osrm.net/Route/RouteItem.cpp
@@ -4,10 +4,13 @@
 
 #include "..\stdafx.h"
 #include "..\Coordinate.h"
+#include "..\Utils.h"
+
 #include "RouteLeg.h"
 #include "RouteParameters.h"
 #include "RouteItem.h"
 #include "RouteWayPoint.h"
+
 
 #include "osrm/json_container.hpp"
 #include "engine/polyline_compressor.hpp"
@@ -58,7 +61,7 @@ Intersection^ ProcessIntersection(const Value jsonIntersection)
 		const auto& laneList = intersection.values.at("lanes").get<Array>().values;
 		for (const auto &lane : laneList)
 		{
-			result->Lanes->Add(msclr::interop::marshal_as<System::String^>(lane.get<String>().value));
+			result->Lanes->Add(Osrmnet::Utils::ConvertFromUtf8(lane.get<String>().value));
 		}
 	}
 
@@ -75,14 +78,14 @@ Maneuver^ ProcessManeuver(Object jsonManeuver)
 	auto result = gcnew Maneuver();
 	result->BearingAfter = System::Convert::ToInt32(jsonManeuver.values.at("bearing_after").get<Number>().value);
 	result->BearingBefore = System::Convert::ToInt32(jsonManeuver.values.at("bearing_before").get<Number>().value);
-	result->Type = msclr::interop::marshal_as<System::String^>(jsonManeuver.values.at("type").get<String>().value);
+	result->Type = Osrmnet::Utils::ConvertFromUtf8(jsonManeuver.values.at("type").get<String>().value);
 	const auto &location = jsonManeuver.values.at("location").get<Array>().values;
 	result->Location = gcnew Osrmnet::Coordinate(location[1].get<Number>().value, location[0].get<Number>().value);
 
 	// Optional Modifier property
 	if(jsonManeuver.values.count("modifier"))
 	{
-		result->Modifier = msclr::interop::marshal_as<System::String^>(jsonManeuver.values.at("modifier").get<String>().value);
+		result->Modifier = Osrmnet::Utils::ConvertFromUtf8(jsonManeuver.values.at("modifier").get<String>().value);
 	}
 
 	// Optional Exit property
@@ -105,11 +108,11 @@ RouteStep^ ProcessStep(Value jsonStep)
 	const auto mode = stepObject.values.at("mode").get<String>().value;
 	const auto geometry = stepObject.values.at("geometry").get<String>().value;
 	
-	routeStep->Geometry = msclr::interop::marshal_as<System::String^>(geometry);
-	routeStep->Mode = msclr::interop::marshal_as<System::String^>(mode);
+	routeStep->Geometry = Osrmnet::Utils::ConvertFromUtf8(geometry);
+	routeStep->Mode = Osrmnet::Utils::ConvertFromUtf8(mode);
 	routeStep->Duration = duration;
 	routeStep->Distance = distance;
-	routeStep->Name = msclr::interop::marshal_as<System::String^>(name);
+	routeStep->Name = Osrmnet::Utils::ConvertFromUtf8(name);
 
 	// Create maneuver
 	routeStep->Maneuver = ProcessManeuver(stepObject.values.at("maneuver").get<Object>());	
@@ -129,22 +132,22 @@ RouteStep^ ProcessStep(Value jsonStep)
 
 	if (stepObject.values.count("pronounciation") > 0)
 	{
-		routeStep->Pronounciation = msclr::interop::marshal_as<System::String^>(stepObject.values.at("pronounciation").get<String>().value);
+		routeStep->Pronounciation = Osrmnet::Utils::ConvertFromUtf8(stepObject.values.at("pronounciation").get<String>().value);
 	}
 
 	if (stepObject.values.count("destinations") > 0)
 	{
-		routeStep->Destinations = msclr::interop::marshal_as<System::String^>(stepObject.values.at("destinations").get<String>().value);
+		routeStep->Destinations = Osrmnet::Utils::ConvertFromUtf8(stepObject.values.at("destinations").get<String>().value);
 	}
 
 	if (stepObject.values.count("rotary_name") > 0)
 	{
-		routeStep->RotaryName = msclr::interop::marshal_as<System::String^>(stepObject.values.at("rotary_name").get<String>().value);
+		routeStep->RotaryName = Osrmnet::Utils::ConvertFromUtf8(stepObject.values.at("rotary_name").get<String>().value);
 	}
 
 	if (stepObject.values.count("rotary_pronounciation") > 0)
 	{
-		routeStep->RotaryName = msclr::interop::marshal_as<System::String^>(stepObject.values.at("rotary_pronounciation").get<String>().value);
+		routeStep->RotaryName = Osrmnet::Utils::ConvertFromUtf8(stepObject.values.at("rotary_pronounciation").get<String>().value);
 	}
 
 	return routeStep;
@@ -160,7 +163,7 @@ RouteLeg^ ProcessRouteLeg(const Value& jsonLeg, bool generateSteps, bool generat
 	auto result = gcnew RouteLeg();
 	result->Distance = distance;
 	result->Duration = duration;
-	result->Summary = msclr::interop::marshal_as<System::String^>(summary);
+	result->Summary = Osrmnet::Utils::ConvertFromUtf8(summary);
 
 	if (generateSteps)
 	{
@@ -200,7 +203,7 @@ RouteItem^ RouteItem::FromJsonObject(const osrm::json::Object& jsonRoute, RouteP
 	result->Distance = jsonRoute.values.at("distance").get<Number>().value;
 	result->Duration = jsonRoute.values.at("duration").get<Number>().value;
 	auto geoJson = jsonRoute.values.at("geometry").get<String>().value;
-	result->Geometry = msclr::interop::marshal_as<System::String^>(geoJson);
+	result->Geometry = Osrmnet::Utils::ConvertFromUtf8(geoJson);
 
 	// Process Legs
 	const auto &osrmLegs = jsonRoute.values.at("legs").get<Array>().values;

--- a/src/osrm.net/Route/RouteResult.cpp
+++ b/src/osrm.net/Route/RouteResult.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.  See included LICENSE in the project root for license information.
 
 #include "..\Stdafx.h"
+#include "..\Utils.h"
 
 #include "RouteResult.h"
 #include "RouteParameters.h"
@@ -21,7 +22,7 @@ RouteResult^ RouteResult::FromJsonObject(const osrm::util::json::Object& jsonObj
 
 	// Code
 	auto codeJson = jsonObject.values.at("code").get<String>().value;
-	result->Code = msclr::interop::marshal_as<System::String^>(codeJson);
+	result->Code = Osrmnet::Utils::ConvertFromUtf8(codeJson);
 	
 	// Process Routes
 	const auto &routesJson = jsonObject.values.at("routes").get<Array>().values;

--- a/src/osrm.net/Route/RouteWayPoint.cpp
+++ b/src/osrm.net/Route/RouteWayPoint.cpp
@@ -3,6 +3,7 @@
 
 #include "..\Stdafx.h"
 #include "..\Coordinate.h"
+#include "..\Utils.h"
 
 #include "RouteWayPoint.h"
 #include "RouteParameters.h"
@@ -18,8 +19,8 @@ RouteWayPoint^ RouteWayPoint::FromJsonObject(const osrm::util::json::Object& jso
 {
 	auto result = gcnew RouteWayPoint();
 
-	result->Hint = msclr::interop::marshal_as<System::String^>(jsonObject.values.at("hint").get<String>().value);
-	result->Name = msclr::interop::marshal_as<System::String^>(jsonObject.values.at("name").get<String>().value);
+	result->Hint = Osrmnet::Utils::ConvertFromUtf8(jsonObject.values.at("hint").get<String>().value);
+	result->Name = Osrmnet::Utils::ConvertFromUtf8(jsonObject.values.at("name").get<String>().value);
 	const auto &location = jsonObject.values.at("location").get<Array>().values;
 	result->Location = gcnew Osrmnet::Coordinate(location[1].get<Number>().value, location[0].get<Number>().value);
 

--- a/src/osrm.net/Utils.cpp
+++ b/src/osrm.net/Utils.cpp
@@ -1,0 +1,10 @@
+#include "Stdafx.h"
+#include "Utils.h"
+
+System::String^ Osrmnet::Utils::ConvertFromUtf8(std::string src)
+{
+	std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+	std::wstring wstr = converter.from_bytes(src);
+
+	return msclr::interop::marshal_as<System::String^>(wstr);
+}

--- a/src/osrm.net/Utils.h
+++ b/src/osrm.net/Utils.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+#include <locale>
+#include <codecvt>
+
+#include <msclr\marshal_cppstd.h>
+
+namespace Osrmnet
+{
+	namespace Utils
+	{
+		System::String^ ConvertFromUtf8(std::string src);
+	}
+};
+

--- a/src/osrm.net/osrm.net.vcxproj
+++ b/src/osrm.net/osrm.net.vcxproj
@@ -135,6 +135,7 @@
     <ClInclude Include="Route\RouteWayPoint.h" />
     <ClInclude Include="Route\RouteItem.h" />
     <ClInclude Include="Stdafx.h" />
+    <ClInclude Include="Utils.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AssemblyInfo.cpp" />
@@ -162,6 +163,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="Utils.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="app.rc" />

--- a/src/osrm.net/osrm.net.vcxproj.filters
+++ b/src/osrm.net/osrm.net.vcxproj.filters
@@ -7,10 +7,19 @@
     <ClCompile Include="OSRM.cpp" />
     <ClCompile Include="Stdafx.cpp" />
     <ClCompile Include="OsrmException.cpp" />
-    <ClCompile Include="Route\RouteParameters.cpp" />
-    <ClCompile Include="Route\RouteItem.cpp" />
-    <ClCompile Include="Route\RouteResult.cpp" />
-    <ClCompile Include="Route\RouteWayPoint.cpp" />
+    <ClCompile Include="Route\RouteWayPoint.cpp">
+      <Filter>Route</Filter>
+    </ClCompile>
+    <ClCompile Include="Route\RouteItem.cpp">
+      <Filter>Route</Filter>
+    </ClCompile>
+    <ClCompile Include="Route\RouteParameters.cpp">
+      <Filter>Route</Filter>
+    </ClCompile>
+    <ClCompile Include="Route\RouteResult.cpp">
+      <Filter>Route</Filter>
+    </ClCompile>
+    <ClCompile Include="Utils.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Coordinate.h" />
@@ -20,16 +29,32 @@
     <ClInclude Include="resource.h" />
     <ClInclude Include="Stdafx.h" />
     <ClInclude Include="OsrmException.h" />
-    <ClInclude Include="Route\RouteLeg.h" />
-    <ClInclude Include="Route\RouteWayPoint.h" />
-    <ClInclude Include="Route\RouteParameters.h" />
-    <ClInclude Include="Route\RouteItem.h" />
-    <ClInclude Include="Route\RouteResult.h" />
+    <ClInclude Include="Route\RouteWayPoint.h">
+      <Filter>Route</Filter>
+    </ClInclude>
+    <ClInclude Include="Route\RouteResult.h">
+      <Filter>Route</Filter>
+    </ClInclude>
+    <ClInclude Include="Route\RouteItem.h">
+      <Filter>Route</Filter>
+    </ClInclude>
+    <ClInclude Include="Route\RouteLeg.h">
+      <Filter>Route</Filter>
+    </ClInclude>
+    <ClInclude Include="Route\RouteParameters.h">
+      <Filter>Route</Filter>
+    </ClInclude>
+    <ClInclude Include="Utils.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="app.rc" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Route">
+      <UniqueIdentifier>{b6390646-0c29-4bba-81c0-3b0a362b2ffa}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Libosrm build by default is using mbcs flag in Windows platform (osrm data is utf8) but .NET string is by default wstr.