### PR TITLE
Fixed issue with Nodes output of NearestWaypoint class

### DIFF
--- a/src/osrm.net/Nearest/NearestWaypoint.cpp
+++ b/src/osrm.net/Nearest/NearestWaypoint.cpp
@@ -16,7 +16,7 @@ using namespace osrm::util::json;
 
 NearestWaypoint::NearestWaypoint(const osrm::util::json::Object& jsonObject) : Waypoint(jsonObject)
 {
-	Nodes = gcnew List<long>(2);
+	Nodes = gcnew List<UINT64>(2);
 }
 
 NearestWaypoint^ NearestWaypoint::FromJsonObject(const osrm::util::json::Object& jsonObject)
@@ -40,7 +40,7 @@ NearestWaypoint^ NearestWaypoint::FromJsonObject(const osrm::util::json::Object&
 
 	const auto& nodes = jsonObject.values.at("nodes").get<Array>().values;
 	for (const auto& node : nodes) {
-		result->Nodes->Add((long)node.get<Number>().value);
+		result->Nodes->Add((UINT64)node.get<Number>().value);
 	}
 
 	result->Distance = jsonObject.values.at("distance").get<Number>().value;

--- a/src/osrm.net/Nearest/NearestWaypoint.cpp
+++ b/src/osrm.net/Nearest/NearestWaypoint.cpp
@@ -9,17 +9,24 @@
 
 #include "osrm/json_container.hpp"
 
+using namespace System::Collections::Generic;
+
 using namespace Osrmnet::NearestService;
 using namespace osrm::util::json;
 
 NearestWaypoint::NearestWaypoint(const osrm::util::json::Object& jsonObject) : Waypoint(jsonObject)
 {
+	Nodes = gcnew List<long>(2);
 }
 
 NearestWaypoint^ NearestWaypoint::FromJsonObject(const osrm::util::json::Object& jsonObject)
 {
 	/*
 	{
+	    "nodes": [
+			1912916988,
+			2286779175
+		],
 		"location": [
 			2.349566,
 			48.82971
@@ -30,6 +37,12 @@ NearestWaypoint^ NearestWaypoint::FromJsonObject(const osrm::util::json::Object&
 	}
 	*/
 	auto result = gcnew NearestWaypoint(jsonObject);
+
+	const auto& nodes = jsonObject.values.at("nodes").get<Array>().values;
+	for (const auto& node : nodes) {
+		result->Nodes->Add((long)node.get<Number>().value);
+	}
+
 	result->Distance = jsonObject.values.at("distance").get<Number>().value;
 	return result;
 }

--- a/src/osrm.net/Nearest/NearestWaypoint.h
+++ b/src/osrm.net/Nearest/NearestWaypoint.h
@@ -15,7 +15,7 @@ namespace Osrmnet {
 		public ref class NearestWaypoint : public Waypoint
 		{
 		public:
-			property IList<long>^ Nodes;
+			property IList<UINT64>^ Nodes;
 			property double Distance;
 
 		internal:

--- a/src/osrm.net/Nearest/NearestWaypoint.h
+++ b/src/osrm.net/Nearest/NearestWaypoint.h
@@ -5,6 +5,8 @@
 #include "..\OsrmFwdDecl.h"
 #include "..\Waypoint.h"
 
+using namespace System::Collections::Generic;
+
 namespace Osrmnet {
 	ref class Coordinate;
 
@@ -13,8 +15,8 @@ namespace Osrmnet {
 		public ref class NearestWaypoint : public Waypoint
 		{
 		public:
+			property IList<long>^ Nodes;
 			property double Distance;
-
 
 		internal:
 			NearestWaypoint(const osrm::util::json::Object&);


### PR DESCRIPTION
The list containing nodes output of the Nearest service in the NearestWaypoint class was using the long type which is usually only 4 bytes, leading to invalid results. NearestWaypoint now specifies UINT64 for the Nodes list, guaranteeing 8 bytes.